### PR TITLE
data.json: Change 'required' field to true for Cartridge

### DIFF
--- a/pkg/pocket/Cores/janisc.NGPC/data.json
+++ b/pkg/pocket/Cores/janisc.NGPC/data.json
@@ -5,7 +5,7 @@
       {
         "name": "Cartridge",
         "id": 0,
-        "required": false,
+        "required": true,
         "parameters": "0x109",
         "extensions": [
           "ngp",


### PR DESCRIPTION
Set `required: true` for the `Cartridge` data slot. With this enabled when a user opens the they'll immediately get the ROM selection screen instead of having to open the menu, goto core settings and loading a ROM.